### PR TITLE
Set default load priority to 0

### DIFF
--- a/Synapse/Api/Plugin/PluginInformation.cs
+++ b/Synapse/Api/Plugin/PluginInformation.cs
@@ -11,7 +11,7 @@ namespace Synapse.Api.Plugin
         public string Author = "Unknown";
         public string Description = "Unknown";
         public string Version = "Unknown";
-        public int LoadPriority = int.MinValue;
+        public int LoadPriority = 0;
 
         internal bool shared = false;
     }


### PR DESCRIPTION
Plugins should be able to use int.MinValue for last priority. It doesn't make sense for it to be the default priority and not allow any plugins to load before them.