### PR TITLE
Add IsEscaping to set class event

### DIFF
--- a/Synapse/Api/Events/SynapseEventArguments/PlayerEventArgs.cs
+++ b/Synapse/Api/Events/SynapseEventArguments/PlayerEventArgs.cs
@@ -225,6 +225,8 @@ namespace Synapse.Api.Events.SynapseEventArguments
         public List<SynapseItem> EscapeItems { get; set; }
 
         public bool Allow { get; set; }
+
+        public bool IsEscaping { get; internal set; }
     }
 
     public class PlayerConnectWorkstationEventArgs : EventHandler.ISynapseEventArgs

--- a/Synapse/Patches/EventsPatches/PlayerPatches/PlayerSetClassPatch.cs
+++ b/Synapse/Patches/EventsPatches/PlayerPatches/PlayerSetClassPatch.cs
@@ -20,6 +20,7 @@ namespace Synapse.Patches.EventsPatches.PlayerPatches
 
             __state = new PlayerSetClassEventArgs();
             __state.EscapeItems = new List<SynapseItem>();
+            __state.IsEscaping = escape;
 
             if (escape && CharacterClassManager.KeepItemsAfterEscaping)
             {


### PR DESCRIPTION
The title explains it. Also, I'm pretty sure there's a bug with the set class event where items are cleared when escaping even if it's canceled, but I haven't tested it.