### PR TITLE
Enum for Teams

### DIFF
--- a/Synapse/Api/Enum/Team.cs
+++ b/Synapse/Api/Enum/Team.cs
@@ -1,0 +1,11 @@
+namespace Synapse.Api.Enum
+{
+    public enum Team
+    {
+        Scp,
+        Mtf,
+        CI,
+        Tutorial,
+        Spectator,
+    }
+}


### PR DESCRIPTION
I will just touch the enum and not the actual code bc I think that the option to just use this enum will make further code related to teams easier to access ^^