### PR TITLE
Added some controls over the lights per room

### DIFF
--- a/Synapse/Api/Map.cs
+++ b/Synapse/Api/Map.cs
@@ -159,15 +159,10 @@ namespace Synapse.Api
                 Teslas.Add(new Tesla(tesla));
 
             foreach (var room in SynapseController.Server.GetObjectsOf<Transform>().Where(x => x.CompareTag("Room") || x.name == "Root_*&*Outside Cams" || x.name == "PocketWorld"))
-                Rooms.Add(new Room(room.gameObject));
-
-            foreach (var lightController in SynapseController.Server.GetObjectsOf<FlickerableLightController>())
             {
-                var distanceOrdered = Rooms.OrderBy(_ => Vector3.Distance(_.Position, lightController.transform.position));
-                //Get the next room which doesnt have a controller yet, which is less or equal than 20 units away from the controller - Exceptions are surface & 173's room
-                Room room = distanceOrdered.FirstOrDefault(_ => !_.HasLightController && (Vector3.Distance(_.Position, lightController.transform.position) <= 20f || _.RoomName == "Root_*&*Outside Cams" || _.RoomName == "LCZ_173"));
-                if (room != null)
-                    room.LightController = lightController;
+                Room synRoom = new Room(room.gameObject);
+                synRoom.LightController = synRoom.GameObject.GetComponentInChildren<FlickerableLightController>();
+                Rooms.Add(synRoom);
             }
 
             foreach (var station in Server.Get.GetObjectsOf<global::WorkStation>())

--- a/Synapse/Api/Map.cs
+++ b/Synapse/Api/Map.cs
@@ -159,23 +159,14 @@ namespace Synapse.Api
                 Teslas.Add(new Tesla(tesla));
 
             foreach (var room in SynapseController.Server.GetObjectsOf<Transform>().Where(x => x.CompareTag("Room") || x.name == "Root_*&*Outside Cams" || x.name == "PocketWorld"))
-            {
-                Room synRoom = new Room(room.gameObject);
-                synRoom.LightController = synRoom.GameObject.GetComponentInChildren<FlickerableLightController>();
-                Rooms.Add(synRoom);
-            }
+                Rooms.Add(new Room(room.gameObject));
+
 
             foreach (var station in Server.Get.GetObjectsOf<global::WorkStation>())
                 WorkStations.Add(new WorkStation(station));
 
             foreach (var door in SynapseController.Server.GetObjectsOf<DoorVariant>())
                 Doors.Add(new Door(door));
-
-#if DEBUG
-            var allRoomLightContrs = Map.Get.Rooms.Select(_ => _.LightController);
-            var allLightContrsFiltered = SynapseController.Server.GetObjectsOf<FlickerableLightController>().Where(_ => !allRoomLightContrs.Contains(_));
-            Logger.Get.Info(allLightContrsFiltered.Count()); //The amount of lone light controllers
-#endif
         }
 
         internal void ClearObjects()

--- a/Synapse/Api/Room.cs
+++ b/Synapse/Api/Room.cs
@@ -10,12 +10,10 @@ namespace Synapse.Api
             var info = gameObject.GetComponentInChildren<RoomInformation>();
             RoomType = info.CurrentRoomType;
             GameObject = gameObject;
-            LightController = null;
+            LightController = GameObject.GetComponentInChildren<FlickerableLightController>();
         }
 
         internal FlickerableLightController LightController { get; set; }
-
-        public bool HasLightController => LightController != null;
 
         public void Overcharge(float duration)
             => LightController.ServerFlickerLights(duration);

--- a/Synapse/Api/Room.cs
+++ b/Synapse/Api/Room.cs
@@ -10,7 +10,18 @@ namespace Synapse.Api
             var info = gameObject.GetComponentInChildren<RoomInformation>();
             RoomType = info.CurrentRoomType;
             GameObject = gameObject;
+            LightController = null;
         }
+
+        internal FlickerableLightController LightController { get; set; }
+
+        public bool HasLightController => LightController != null;
+
+        public void Overcharge(float duration)
+            => LightController.ServerFlickerLights(duration);
+
+        public void SetLightIntensity(float intensity)
+            => LightController.ServerSetLightIntensity(intensity);
 
         public GameObject GameObject { get; }
 
@@ -35,7 +46,6 @@ namespace Synapse.Api
                             return ZoneType.HCZ;
 
                         return ZoneType.Entrance;
-
 
                     case -2000f:
                         return ZoneType.Pocket;


### PR DESCRIPTION
Within SCP SL, each room has their own `FlickerableLightController`, responsible for the lighting.  
I added this Controller to each Room to give per-room light accessibility.
Tested, however with imperfections. For whatever reason, the map generation decides to put some of the Controllers for each room 20 - 100 Unity-units away (distance). This is a problem, because it is indistinguishable whether a certain controller belongs to one room or another purely by the distance, which this here is based on. However, distance might not be the only identifier for which controller belongs to which room. I'll be on the look out for a better solution.

PS.: I will leave some notes within the code.