### PR TITLE
Various 079 events & camera collections

### DIFF
--- a/Synapse/Api/Elevator.cs
+++ b/Synapse/Api/Elevator.cs
@@ -7,7 +7,7 @@ namespace Synapse.Api
     {
         internal Elevator(Lift lift) => Lift = lift;
 
-        private readonly Lift Lift;
+        internal Lift Lift { get; }
 
         public GameObject GameObject => Lift.gameObject;
 
@@ -19,9 +19,11 @@ namespace Synapse.Api
 
         public bool Locked { get => Lift._locked; set => Lift.SetLock(value); }
 
+        public bool Operative { get => Lift.operative; }
+
         public float MaxDistance { get => Lift.maxDistance; set => Lift.maxDistance = value; }
 
-        public void Use() => Lift.UseLift();
+        public bool Use() => Lift.UseLift();
 
         public ElevatorType ElevatorType
         {

--- a/Synapse/Api/Events/ScpEvents.cs
+++ b/Synapse/Api/Events/ScpEvents.cs
@@ -1,5 +1,7 @@
 ﻿using Synapse.Api.Events.SynapseEventArguments;
 using Synapse.Api.Enum;
+using System.Collections.Generic;
+using Interactables.Interobjects.DoorUtils;
 
 namespace Synapse.Api.Events
 {
@@ -119,6 +121,8 @@ namespace Synapse.Api.Events
 
             public event EventHandler.OnSynapseEvent<Scp079RoomLockdownEventArgs> Scp079RoomLockdown;
 
+            public event EventHandler.OnSynapseEvent<Scp079TeslaInteractEventArgs> Scp079TeslaInteract;
+
             internal void Invoke079RecontainEvent(Recontain079Status status, out bool allow)
             {
                 var ev = new Scp079RecontainEventArgs
@@ -198,6 +202,7 @@ namespace Synapse.Api.Events
                 Player player,
                 float energyNeeded,
                 Room room,
+                ref bool lightsOut,
                 Scp079EventMisc.InteractionResult intendedResult,
                 out Scp079EventMisc.InteractionResult actualResult
                 )
@@ -207,10 +212,34 @@ namespace Synapse.Api.Events
                     Scp079 = player,
                     Result = intendedResult,
                     EnergyNeeded = energyNeeded,
-                    Room = room
+                    Room = room,
+                    LightsOut = lightsOut
                 };
 
                 Scp079RoomLockdown?.Invoke(ev);
+
+                actualResult = ev.Result;
+            }
+
+            internal void Invoke079TeslaInteract(
+                Player player,
+                float energyNeeded,
+                Room room,
+                Tesla tesla,
+                Scp079EventMisc.InteractionResult intendedResult,
+                out Scp079EventMisc.InteractionResult actualResult
+                )
+            {
+                var ev = new Scp079TeslaInteractEventArgs
+                {
+                    Scp079 = player,
+                    Result = intendedResult,
+                    EnergyNeeded = energyNeeded,
+                    Room = room,
+                    Tesla = tesla
+                };
+
+                Scp079TeslaInteract?.Invoke(ev);
 
                 actualResult = ev.Result;
             }

--- a/Synapse/Api/Events/ScpEvents.cs
+++ b/Synapse/Api/Events/ScpEvents.cs
@@ -111,17 +111,19 @@ namespace Synapse.Api.Events
         {
             internal Scp079Events() { }
 
-            public event EventHandler.OnSynapseEvent<Scp079RecontainEventArgs> Scp079RecontainEvent;
+            public event EventHandler.OnSynapseEvent<Scp079RecontainEventArgs> RecontainEvent;
 
-            public event EventHandler.OnSynapseEvent<Scp079DoorInteractEventArgs> Scp079DoorInteract;
+            public event EventHandler.OnSynapseEvent<Scp079DoorInteractEventArgs> DoorInteract;
 
-            public event EventHandler.OnSynapseEvent<Scp079SpeakerInteractEventArgs> Scp079SpeakerInteract;
+            public event EventHandler.OnSynapseEvent<Scp079SpeakerInteractEventArgs> SpeakerInteract;
 
-            public event EventHandler.OnSynapseEvent<Scp079ElevatorUseEventArgs> Scp079ElevatorUse;
+            public event EventHandler.OnSynapseEvent<Scp079ElevatorInteractEventArgs> ElevatorInteract;
 
-            public event EventHandler.OnSynapseEvent<Scp079RoomLockdownEventArgs> Scp079RoomLockdown;
+            public event EventHandler.OnSynapseEvent<Scp079RoomLockdownEventArgs> RoomLockdown;
 
-            public event EventHandler.OnSynapseEvent<Scp079TeslaInteractEventArgs> Scp079TeslaInteract;
+            public event EventHandler.OnSynapseEvent<Scp079TeslaInteractEventArgs> TeslaInteract;
+
+            public event EventHandler.OnSynapseEvent<Scp079CameraSwitchEventArgs> CameraSwitch;
 
             internal void Invoke079RecontainEvent(Recontain079Status status, out bool allow)
             {
@@ -130,7 +132,7 @@ namespace Synapse.Api.Events
                     Status = status
                 };
 
-                Scp079RecontainEvent?.Invoke(ev);
+                RecontainEvent?.Invoke(ev);
 
                 allow = ev.Allow;
             }
@@ -153,7 +155,7 @@ namespace Synapse.Api.Events
                     Door = door
                 };
 
-                Scp079DoorInteract?.Invoke(ev);
+                DoorInteract?.Invoke(ev);
 
                 actualResult = ev.Result;
             }
@@ -172,7 +174,7 @@ namespace Synapse.Api.Events
                     EnergyNeeded = energyNeeded
                 };
 
-                Scp079SpeakerInteract?.Invoke(ev);
+                SpeakerInteract?.Invoke(ev);
 
                 actualResult = ev.Result;
             }
@@ -185,7 +187,7 @@ namespace Synapse.Api.Events
                 out Scp079EventMisc.InteractionResult actualResult
                 )
             {
-                var ev = new Scp079ElevatorUseEventArgs
+                var ev = new Scp079ElevatorInteractEventArgs
                 {
                     Scp079 = player,
                     Result = intendedResult,
@@ -193,7 +195,7 @@ namespace Synapse.Api.Events
                     Elevator = elevator
                 };
 
-                Scp079ElevatorUse?.Invoke(ev);
+                ElevatorInteract?.Invoke(ev);
 
                 actualResult = ev.Result;
             }
@@ -216,7 +218,7 @@ namespace Synapse.Api.Events
                     LightsOut = lightsOut
                 };
 
-                Scp079RoomLockdown?.Invoke(ev);
+                RoomLockdown?.Invoke(ev);
 
                 actualResult = ev.Result;
             }
@@ -239,9 +241,32 @@ namespace Synapse.Api.Events
                     Tesla = tesla
                 };
 
-                Scp079TeslaInteract?.Invoke(ev);
+                TeslaInteract?.Invoke(ev);
 
                 actualResult = ev.Result;
+            }
+
+            internal void Invoke079CameraSwitch(
+                Player player,
+                Camera079 cam,
+                bool mapSwitch,
+                bool spawning,
+                out bool allow
+                )
+            {
+                var ev = new Scp079CameraSwitchEventArgs
+                {
+                    Scp079 = player,
+                    MapSwitch = mapSwitch,
+                    Camera = cam,
+                    Spawning = spawning,
+                    Allow = true
+                };
+
+                CameraSwitch?.Invoke(ev);
+
+                //If allowed by the event methods, or if this is the first spawning
+                allow = ev.Allow || ev.Spawning;
             }
         }
 

--- a/Synapse/Api/Events/ScpEvents.cs
+++ b/Synapse/Api/Events/ScpEvents.cs
@@ -8,7 +8,7 @@ namespace Synapse.Api.Events
         internal ScpEvents() { }
 
         public Scp096Events Scp096 { get; } = new Scp096Events();
-        
+
         public Scp106Events Scp106 { get; } = new Scp106Events();
 
         public Scp079Events Scp079 { get; } = new Scp079Events();
@@ -51,7 +51,7 @@ namespace Synapse.Api.Events
             public event EventHandler.OnSynapseEvent<Scp106ContainmentEventArgs> Scp106ContainmentEvent;
 
             public event EventHandler.OnSynapseEvent<PocketDimensionEnterEventArgs> PocketDimensionEnterEvent;
-            
+
             public event EventHandler.OnSynapseEvent<PocketDimensionLeaveEventArgs> PocketDimensionLeaveEvent;
 
             public event EventHandler.OnSynapseEvent<PortalCreateEventArgs> PortalCreateEvent;
@@ -60,7 +60,7 @@ namespace Synapse.Api.Events
 
             internal void InvokeScp106ContainmentEvent(Player player, ref bool allow)
             {
-                var ev = new Scp106ContainmentEventArgs {Allow = allow, Player = player};
+                var ev = new Scp106ContainmentEventArgs { Allow = allow, Player = player };
                 Scp106ContainmentEvent?.Invoke(ev);
                 allow = ev.Allow;
             }
@@ -68,13 +68,13 @@ namespace Synapse.Api.Events
             internal void InvokePocketDimensionEnterEvent(Player player, Player scp106, ref bool allow)
             {
                 var ev = new PocketDimensionEnterEventArgs
-                    {Allow = allow, Scp106 = scp106, Player = player};
+                { Allow = allow, Scp106 = scp106, Player = player };
                 PocketDimensionEnterEvent?.Invoke(ev);
 
                 allow = ev.Allow;
             }
-            
-            internal void InvokePocketDimensionLeaveEvent(Player player,ref UnityEngine.Vector3 pos, ref PocketDimensionTeleport.PDTeleportType teleportType, out bool allow)
+
+            internal void InvokePocketDimensionLeaveEvent(Player player, ref UnityEngine.Vector3 pos, ref PocketDimensionTeleport.PDTeleportType teleportType, out bool allow)
             {
                 var ev = new PocketDimensionLeaveEventArgs
                 {
@@ -111,7 +111,15 @@ namespace Synapse.Api.Events
 
             public event EventHandler.OnSynapseEvent<Scp079RecontainEventArgs> Scp079RecontainEvent;
 
-            internal void Invoke079RecontainEvent(Recontain079Status status,out bool allow)
+            public event EventHandler.OnSynapseEvent<Scp079DoorInteractEventArgs> Scp079DoorInteract;
+
+            public event EventHandler.OnSynapseEvent<Scp079SpeakerInteractEventArgs> Scp079SpeakerInteract;
+
+            public event EventHandler.OnSynapseEvent<Scp079ElevatorUseEventArgs> Scp079ElevatorUse;
+
+            public event EventHandler.OnSynapseEvent<Scp079RoomLockdownEventArgs> Scp079RoomLockdown;
+
+            internal void Invoke079RecontainEvent(Recontain079Status status, out bool allow)
             {
                 var ev = new Scp079RecontainEventArgs
                 {
@@ -122,8 +130,91 @@ namespace Synapse.Api.Events
 
                 allow = ev.Allow;
             }
-        }
 
+            internal void Invoke079DoorInteract(
+                Player player,
+                Scp079EventMisc.DoorAction action,
+                Scp079EventMisc.InteractionResult intendedResult,
+                float energyNeeded,
+                Door door,
+                out Scp079EventMisc.InteractionResult actualResult
+                )
+            {
+                var ev = new Scp079DoorInteractEventArgs
+                {
+                    Scp079 = player,
+                    Action = action,
+                    EnergyNeeded = energyNeeded,
+                    Result = intendedResult,
+                    Door = door
+                };
+
+                Scp079DoorInteract?.Invoke(ev);
+
+                actualResult = ev.Result;
+            }
+
+            internal void Invoke079SpeakerInteract(
+                Player player,
+                float energyNeeded,
+                Scp079EventMisc.InteractionResult intendedResult,
+                out Scp079EventMisc.InteractionResult actualResult
+                )
+            {
+                var ev = new Scp079SpeakerInteractEventArgs
+                {
+                    Scp079 = player,
+                    Result = intendedResult,
+                    EnergyNeeded = energyNeeded
+                };
+
+                Scp079SpeakerInteract?.Invoke(ev);
+
+                actualResult = ev.Result;
+            }
+
+            internal void Invoke079ElevatorUse(
+                Player player,
+                float energyNeeded,
+                Elevator elevator,
+                Scp079EventMisc.InteractionResult intendedResult,
+                out Scp079EventMisc.InteractionResult actualResult
+                )
+            {
+                var ev = new Scp079ElevatorUseEventArgs
+                {
+                    Scp079 = player,
+                    Result = intendedResult,
+                    EnergyNeeded = energyNeeded,
+                    Elevator = elevator
+                };
+
+                Scp079ElevatorUse?.Invoke(ev);
+
+                actualResult = ev.Result;
+            }
+
+            internal void Invoke079RoomLockdown(
+                Player player,
+                float energyNeeded,
+                Room room,
+                Scp079EventMisc.InteractionResult intendedResult,
+                out Scp079EventMisc.InteractionResult actualResult
+                )
+            {
+                var ev = new Scp079RoomLockdownEventArgs
+                {
+                    Scp079 = player,
+                    Result = intendedResult,
+                    EnergyNeeded = energyNeeded,
+                    Room = room
+                };
+
+                Scp079RoomLockdown?.Invoke(ev);
+
+                actualResult = ev.Result;
+            }
+        }
 
         public class Scp173Events
         {
@@ -141,7 +232,8 @@ namespace Synapse.Api.Events
                 Scp173BlinkEvent?.Invoke(ev);
             }
         }
-        internal void InvokeScpAttack(Player scp,Player target,Enum.ScpAttackType attackType , out bool allow)
+
+        internal void InvokeScpAttack(Player scp, Player target, Enum.ScpAttackType attackType, out bool allow)
         {
             var ev = new ScpAttackEventArgs
             {

--- a/Synapse/Api/Events/SynapseEventArguments/ScpEventArgs.cs
+++ b/Synapse/Api/Events/SynapseEventArguments/ScpEventArgs.cs
@@ -115,6 +115,15 @@ namespace Synapse.Api.Events.SynapseEventArguments
         public Player Scp079 { get; internal set; }
         public float EnergyNeeded { get; internal set; }
         public Room Room { get; internal set; }
+        public bool LightsOut { get; set; }
+        public Scp079EventMisc.InteractionResult Result { get; set; }
+    }
+    public class Scp079TeslaInteractEventArgs : EventHandler.ISynapseEventArgs
+    {
+        public Player Scp079 { get; internal set; }
+        public float EnergyNeeded { get; internal set; }
+        public Room Room { get; internal set; }
+        public Tesla Tesla { get; internal set; }
         public Scp079EventMisc.InteractionResult Result { get; set; }
     }
 }

--- a/Synapse/Api/Events/SynapseEventArguments/ScpEventArgs.cs
+++ b/Synapse/Api/Events/SynapseEventArguments/ScpEventArgs.cs
@@ -103,7 +103,7 @@ namespace Synapse.Api.Events.SynapseEventArguments
         public float EnergyNeeded { get; internal set; }
         public Scp079EventMisc.InteractionResult Result { get; set; }
     }
-    public class Scp079ElevatorUseEventArgs : EventHandler.ISynapseEventArgs
+    public class Scp079ElevatorInteractEventArgs : EventHandler.ISynapseEventArgs
     {
         public Player Scp079 { get; internal set; }
         public float EnergyNeeded { get; internal set; }
@@ -125,5 +125,13 @@ namespace Synapse.Api.Events.SynapseEventArguments
         public Room Room { get; internal set; }
         public Tesla Tesla { get; internal set; }
         public Scp079EventMisc.InteractionResult Result { get; set; }
+    }
+    public class Scp079CameraSwitchEventArgs : EventHandler.ISynapseEventArgs
+    {
+        public Player Scp079 { get; internal set; }
+        public Camera079 Camera { get; internal set; }
+        public bool Spawning { get; internal set; }
+        public bool MapSwitch { get; internal set; }
+        public bool Allow { get; set; }
     }
 }

--- a/Synapse/Api/Events/SynapseEventArguments/ScpEventArgs.cs
+++ b/Synapse/Api/Events/SynapseEventArguments/ScpEventArgs.cs
@@ -17,16 +17,16 @@ namespace Synapse.Api.Events.SynapseEventArguments
     public class Scp106ContainmentEventArgs : EventHandler.ISynapseEventArgs
     {
         public Player Player { get; internal set; }
-        
+
         public bool Allow { get; set; }
     }
 
     public class PocketDimensionEnterEventArgs : EventHandler.ISynapseEventArgs
     {
         public Player Player { get; internal set; }
-        
+
         public Player Scp106 { get; internal set; }
-        
+
         public bool Allow { get; set; }
     }
 
@@ -35,7 +35,7 @@ namespace Synapse.Api.Events.SynapseEventArguments
         public Player Player { get; internal set; }
 
         public Vector3 ExitPosition { get; set; }
-        
+
         public PocketDimensionTeleport.PDTeleportType TeleportType { get; set; }
 
         public bool Allow { get; set; } = true;
@@ -69,5 +69,52 @@ namespace Synapse.Api.Events.SynapseEventArguments
     public class Scp173BlinkEventArgs : EventHandler.ISynapseEventArgs
     {
         public Player Scp173 { get; internal set; }
+    }
+
+
+    public class Scp079EventMisc
+    {
+        public enum InteractionResult
+        {
+            Allow,
+            Disallow,
+            NoEnergy
+        }
+        public enum DoorAction
+        {
+            Opening,
+            Closing,
+            Locking,
+            Unlocking
+        }
+    }
+    public class Scp079DoorInteractEventArgs : EventHandler.ISynapseEventArgs
+    {
+        public Player Scp079 { get; internal set; }
+        public Scp079EventMisc.DoorAction Action { get; internal set; }
+        public float EnergyNeeded { get; internal set; }
+        public Door Door { get; internal set; }
+        public Scp079EventMisc.InteractionResult Result { get; set; }
+
+    }
+    public class Scp079SpeakerInteractEventArgs : EventHandler.ISynapseEventArgs
+    {
+        public Player Scp079 { get; internal set; }
+        public float EnergyNeeded { get; internal set; }
+        public Scp079EventMisc.InteractionResult Result { get; set; }
+    }
+    public class Scp079ElevatorUseEventArgs : EventHandler.ISynapseEventArgs
+    {
+        public Player Scp079 { get; internal set; }
+        public float EnergyNeeded { get; internal set; }
+        public Elevator Elevator { get; internal set; }
+        public Scp079EventMisc.InteractionResult Result { get; set; }
+    }
+    public class Scp079RoomLockdownEventArgs : EventHandler.ISynapseEventArgs
+    {
+        public Player Scp079 { get; internal set; }
+        public float EnergyNeeded { get; internal set; }
+        public Room Room { get; internal set; }
+        public Scp079EventMisc.InteractionResult Result { get; set; }
     }
 }

--- a/Synapse/Api/Map.cs
+++ b/Synapse/Api/Map.cs
@@ -45,6 +45,8 @@ namespace Synapse.Api
 
         public List<Dummy> Dummies { get; } = new List<Dummy>();
 
+        public List<Camera079> Cameras { get; } = new List<Camera079>();
+
         public string IntercomText
         {
             get => Server.Get.Host.GetComponent<Intercom>().CustomContent;
@@ -81,13 +83,13 @@ namespace Synapse.Api
 
         public int Seed => MapGeneration.SeedSynchronizer.Seed;
 
-        public Room GetRoom(RoomInformation.RoomType roomType) 
+        public Room GetRoom(RoomInformation.RoomType roomType)
             => Rooms.FirstOrDefault(x => x.RoomType == roomType);
 
-        public Door GetDoor(Enum.DoorType doorType) 
+        public Door GetDoor(Enum.DoorType doorType)
             => Doors.FirstOrDefault(x => x.DoorType == doorType);
 
-        public Elevator GetElevator(Enum.ElevatorType elevatorType) 
+        public Elevator GetElevator(Enum.ElevatorType elevatorType)
             => Elevators.FirstOrDefault(x => x.ElevatorType == elevatorType);
 
         public void SendBroadcast(ushort time, string message, bool instant = false)
@@ -102,7 +104,7 @@ namespace Synapse.Api
             GlitchedCassie(text);
         }
 
-        public void Cassie(string words, bool makehold = true, bool makenoise = true) 
+        public void Cassie(string words, bool makehold = true, bool makenoise = true)
             => Respawning.RespawnEffectsController.PlayCassieAnnouncement(words, makehold, makenoise);
 
         public void GlitchedCassie(string words)
@@ -145,11 +147,11 @@ namespace Synapse.Api
             => new Dummy(pos, rot, role, name, badgetext, badgecolor);
 
         [Obsolete("Moved to Workstation.CreateWorkStation()", true)]
-        public WorkStation CreateWorkStation(Vector3 position, Vector3 rotation, Vector3 scale) 
+        public WorkStation CreateWorkStation(Vector3 position, Vector3 rotation, Vector3 scale)
             => new WorkStation(position, rotation, scale);
 
         [Obsolete("Moved to Ragdoll.CreateRagdoll()", true)]
-        public Ragdoll CreateRagdoll(RoleType roletype, Vector3 pos, Quaternion rot, Vector3 velocity, PlayerStats.HitInfo info, bool allowRecall, Player owner) 
+        public Ragdoll CreateRagdoll(RoleType roletype, Vector3 pos, Quaternion rot, Vector3 velocity, PlayerStats.HitInfo info, bool allowRecall, Player owner)
             => new Ragdoll(roletype, pos, rot, velocity, info, allowRecall, owner);
 
         [Obsolete("Moved to Door.SpawnDoorVariant()", true)]
@@ -169,11 +171,15 @@ namespace Synapse.Api
 
         internal void AddObjects()
         {
+            foreach (var room in SynapseController.Server.GetObjectsOf<Transform>().Where(x => x.CompareTag("Room") || x.name == "Root_*&*Outside Cams" || x.name == "PocketWorld"))
+            {
+                var synRoom = new Room(room.gameObject);
+                Rooms.Add(synRoom);
+                Cameras.AddRange(synRoom.Cameras);
+            }
+
             foreach (var tesla in SynapseController.Server.GetObjectsOf<TeslaGate>())
                 Teslas.Add(new Tesla(tesla));
-
-            foreach (var room in SynapseController.Server.GetObjectsOf<Transform>().Where(x => x.CompareTag("Room") || x.name == "Root_*&*Outside Cams" || x.name == "PocketWorld"))
-                Rooms.Add(new Room(room.gameObject));
 
             foreach (var station in Server.Get.GetObjectsOf<global::WorkStation>())
                 WorkStations.Add(new WorkStation(station));

--- a/Synapse/Api/Room.cs
+++ b/Synapse/Api/Room.cs
@@ -1,6 +1,7 @@
 ﻿using Synapse.Api.Enum;
 using UnityEngine;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Synapse.Api
 {
@@ -12,6 +13,7 @@ namespace Synapse.Api
             RoomType = info.CurrentRoomType;
             GameObject = gameObject;
             LightController = GameObject.GetComponentInChildren<FlickerableLightController>();
+            Cameras = GameObject.GetComponentsInChildren<Camera079>().ToList();
         }
 
         internal FlickerableLightController LightController { get; set; }
@@ -29,6 +31,8 @@ namespace Synapse.Api
         public string RoomName => GameObject.name;
 
         public List<Door> Doors { get; } = new List<Door>();
+
+        public List<Camera079> Cameras { get; } = new List<Camera079>();
 
         public ZoneType Zone
         {

--- a/Synapse/Api/Scp079Controller.cs
+++ b/Synapse/Api/Scp079Controller.cs
@@ -8,6 +8,7 @@
 
         private Scp079PlayerScript Script => player.ClassManager.Scp079;
 
+        internal bool Spawned { get; set; }
 
         public bool Is079 => player.RoleType == RoleType.Scp079;
 
@@ -25,7 +26,6 @@
         /// The current camera the player uses (Scp079 only, if not null)
         /// </summary>
         public Camera079 Camera { get => Script.currentCamera; set => Script?.RpcSwitchCamera(value.cameraId, false); }
-
 
         public void GiveExperience(float amount) => Script.AddExperience(amount);
 

--- a/Synapse/Api/Tesla.cs
+++ b/Synapse/Api/Tesla.cs
@@ -1,12 +1,19 @@
-﻿using UnityEngine;
+﻿using System.Linq;
+using UnityEngine;
 
 namespace Synapse.Api
 {
     public class Tesla
     {
-        internal Tesla(TeslaGate gate) => Gate = gate;
+        internal Tesla(TeslaGate gate)
+        {
+            Gate = gate;
+            Room = Server.Get.Map.Rooms.OrderBy(room => Vector3.Distance(room.Position, gate.localPosition)).First();
+        }
 
-        private readonly TeslaGate Gate;
+        internal TeslaGate Gate { get; }
+
+        public Room Room { get; internal set; }
 
         public GameObject GameObject => Gate.gameObject;
 

--- a/Synapse/Patches/EventsPatches/ScpPatches/Scp079/Scp079BulkPatch.cs
+++ b/Synapse/Patches/EventsPatches/ScpPatches/Scp079/Scp079BulkPatch.cs
@@ -1,0 +1,560 @@
+﻿using HarmonyLib;
+using Interactables.Interobjects;
+using Interactables.Interobjects.DoorUtils;
+using NorthwoodLib.Pools;
+using Synapse.Api;
+using Synapse.Api.Events.SynapseEventArguments;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace Synapse.Patches.EventsPatches.ScpPatches.Scp079
+{
+    [HarmonyPatch(typeof(Scp079PlayerScript), nameof(Scp079PlayerScript.CallCmdInteract))]
+    public static class Scp079BulkPatch
+    {
+        public static bool Prefix(Scp079PlayerScript __instance, string command, GameObject target)
+        {
+            try
+            {
+                if (!__instance._interactRateLimit.CanExecute(true))
+                {
+                    return false;
+                }
+                if (!__instance.iAm079)
+                {
+                    return false;
+                }
+                GameCore.Console.AddDebugLog("SCP079", "Command received from a client: " + command, MessageImportance.LessImportant, false);
+                if (!command.Contains(":"))
+                {
+                    return false;
+                }
+                string[] array = command.Split(':');
+                __instance.RefreshCurrentRoom();
+                if (!__instance.CheckInteractableLegitness(__instance.currentRoom, __instance.currentZone, target, true))
+                {
+                    return false;
+                }
+                DoorVariant doorVariant = null;
+                bool flag = target != null && target.TryGetComponent<DoorVariant>(out doorVariant);
+                List<string> list = GameCore.ConfigFile.ServerConfig.GetStringList("scp079_door_blacklist") ?? new List<string>();
+                string text = array[0];
+
+                switch (text)
+                {
+                    case "TESLA":
+                        {
+                            float manaFromLabel = __instance.GetManaFromLabel("Tesla Gate Burst", __instance.abilities);
+                            if (manaFromLabel > __instance.curMana)
+                            {
+                                __instance.RpcNotEnoughMana(manaFromLabel, __instance.curMana);
+                                return false;
+                            }
+                            GameObject gameObject = GameObject.Find(__instance.currentZone + "/" + __instance.currentRoom + "/Gate");
+                            if (gameObject != null)
+                            {
+                                gameObject.GetComponent<TeslaGate>().RpcInstantBurst();
+                                __instance.AddInteractionToHistory(gameObject, array[0], true);
+                                __instance.Mana -= manaFromLabel;
+                                return false;
+                            }
+                            break;
+                        }
+                    case "LOCKDOWN":
+                        {
+                            if (AlphaWarheadController.Host.inProgress)
+                            {
+                                GameCore.Console.AddDebugLog("SCP079", "Lockdown cannot commence, Warhead in progress.", MessageImportance.LessImportant, false);
+                                return false;
+                            }
+                            float manaFromLabel = __instance.GetManaFromLabel("Room Lockdown", __instance.abilities);
+                            if (manaFromLabel > __instance.curMana)
+                            {
+                                __instance.RpcNotEnoughMana(manaFromLabel, __instance.curMana);
+                                GameCore.Console.AddDebugLog("SCP079", "Lockdown cannot commence, not enough mana.", MessageImportance.LessImportant, false);
+                                return false;
+                            }
+                            GameCore.Console.AddDebugLog("SCP079", "Attempting lockdown...", MessageImportance.LeastImportant, false);
+                            GameObject gameObject2 = GameObject.Find(__instance.currentZone + "/" + __instance.currentRoom);
+                            if (gameObject2 != null)
+                            {
+                                List<Scp079Interactable> localInteractableList = ListPool<Scp079Interactable>.Shared.Rent();
+                                try
+                                {
+                                    foreach (Scp079Interactable scp079Interactable4 in Interface079.singleton.allInteractables)
+                                    {
+                                        if (scp079Interactable4 != null)
+                                        {
+                                            foreach (Scp079Interactable.ZoneAndRoom zoneAndRoom in scp079Interactable4.currentZonesAndRooms)
+                                            {
+                                                if (zoneAndRoom.currentRoom == __instance.currentRoom && zoneAndRoom.currentZone == __instance.currentZone && scp079Interactable4.transform.position.y - 100f < __instance.currentCamera.transform.position.y && !localInteractableList.Contains(scp079Interactable4))
+                                                {
+                                                    localInteractableList.Add(scp079Interactable4);
+                                                }
+                                            }
+                                        }
+                                    }
+                                    GameCore.Console.AddDebugLog("SCP079", "Loaded all interactables", MessageImportance.LeastImportant, false);
+                                }
+                                catch
+                                {
+                                    GameCore.Console.AddDebugLog("SCP079", "Failed to load interactables.", MessageImportance.LeastImportant, false);
+                                }
+                                GameObject gameObject3 = null;
+                                foreach (Scp079Interactable interactable in localInteractableList)
+                                {
+                                    Scp079Interactable.InteractableType interactableType = interactable.type;
+                                    if (interactableType != Scp079Interactable.InteractableType.Door)
+                                    {
+                                        if (interactableType == Scp079Interactable.InteractableType.Lockdown)
+                                        {
+                                            gameObject3 = interactable.gameObject;
+                                        }
+                                    }
+                                    else
+                                    {
+                                        if (interactable.TryGetComponent(out DoorVariant doorVariant2))
+                                        {
+                                            Synapse.Api.Door door = doorVariant2.GetDoor();
+                                            if (door.VDoor is BreakableDoor bDoor && bDoor.IsDestroyed)
+                                            {
+                                                GameCore.Console.AddDebugLog("SCP079", "Lockdown can't initiate, one of the doors were destroyed.", MessageImportance.LessImportant, false);
+                                                return false;
+                                            }
+                                        }
+                                    }
+                                }
+                                if (localInteractableList.Count == 0 || gameObject3 == null || __instance._scheduledUnlocks.Count > 0)
+                                {
+                                    GameCore.Console.AddDebugLog("SCP079", "This room can't be locked down.", MessageImportance.LessImportant, false);
+                                    return false;
+                                }
+                                HashSet<DoorVariant> hashSet = new HashSet<DoorVariant>();
+                                GameCore.Console.AddDebugLog("SCP079", "Looking for doors to lock...", MessageImportance.LeastImportant, false);
+                                for (int i = 0; i < localInteractableList.Count; i++)
+                                {
+                                    if (localInteractableList[i].TryGetComponent(out DoorVariant doorVariant3))
+                                    {
+                                        bool flag2 = doorVariant3.ActiveLocks == 0;
+                                        if (!flag2)
+                                        {
+                                            DoorLockMode mode = DoorLockUtils.GetMode((DoorLockReason)doorVariant3.ActiveLocks);
+                                            flag2 = (mode.HasFlagFast(DoorLockMode.CanClose) || mode.HasFlagFast(DoorLockMode.ScpOverride));
+                                        }
+                                        if (flag2)
+                                        {
+                                            if (doorVariant3.TargetState)
+                                            {
+                                                doorVariant3.NetworkTargetState = false;
+                                            }
+                                            doorVariant3.ServerChangeLock(Interactables.Interobjects.DoorUtils.DoorLockReason.Lockdown079, true);
+                                            hashSet.Add(doorVariant3);
+                                        }
+                                    }
+                                }
+                                if (hashSet.Count > 0)
+                                {
+                                    __instance._scheduledUnlocks.Add(Time.realtimeSinceStartup + 10f, hashSet);
+                                    GameCore.Console.AddDebugLog("SCP079", "Locking " + hashSet.Count + " doors", MessageImportance.LeastImportant, false);
+                                }
+                                else
+                                {
+                                    GameCore.Console.AddDebugLog("SCP079", "No doors to lock found, code " + (from x in localInteractableList
+                                                                                                              where x.type == Scp079Interactable.InteractableType.Door
+                                                                                                              select x).Count(), MessageImportance.LessImportant, false);
+                                }
+                                ListPool<Scp079Interactable>.Shared.Return(localInteractableList);
+                                foreach (FlickerableLightController flickerableLightController in gameObject2.GetComponentsInChildren<FlickerableLightController>())
+                                {
+                                    if (flickerableLightController != null)
+                                    {
+                                        flickerableLightController.ServerFlickerLights(8f);
+                                    }
+                                }
+                                GameCore.Console.AddDebugLog("SCP079", "Lockdown initiated.", MessageImportance.LessImportant, false);
+                                __instance.AddInteractionToHistory(gameObject3, array[0], true);
+                                __instance.Mana -= __instance.GetManaFromLabel("Room Lockdown", __instance.abilities);
+                                return false;
+                            }
+                            else
+                            {
+                                GameCore.Console.AddDebugLog("SCP079", "Room couldn't be specified.", MessageImportance.Normal, false);
+                            }
+                            break;
+                        }
+                    case "ELEVATORTELEPORT":
+                        {
+                            float manaFromLabel = __instance.GetManaFromLabel("Elevator Teleport", __instance.abilities);
+                            if (manaFromLabel > __instance.curMana)
+                            {
+                                __instance.RpcNotEnoughMana(manaFromLabel, __instance.curMana);
+                                return false;
+                            }
+                            Camera079 camera = null;
+                            foreach (Scp079Interactable scp079Interactable in __instance.nearbyInteractables)
+                            {
+                                if (scp079Interactable.type == Scp079Interactable.InteractableType.ElevatorTeleport)
+                                {
+                                    camera = scp079Interactable.optionalObject.GetComponent<Camera079>();
+                                }
+                            }
+                            if (camera != null)
+                            {
+                                __instance.RpcSwitchCamera(camera.cameraId, false);
+                                __instance.Mana -= manaFromLabel;
+                                __instance.AddInteractionToHistory(target, array[0], true);
+                                return false;
+                            }
+                            Color32 color;
+                            if (ConsoleDebugMode.CheckImportance("SCP079", MessageImportance.LeastImportant, out color))
+                            {
+                                Scp079Interactable scp079Interactable2 = null;
+                                Dictionary<Scp079Interactable.InteractableType, byte> dictionary = new Dictionary<Scp079Interactable.InteractableType, byte>();
+                                foreach (Scp079Interactable scp079Interactable3 in __instance.nearbyInteractables)
+                                {
+                                    if (dictionary.ContainsKey(scp079Interactable3.type))
+                                    {
+                                        Dictionary<Scp079Interactable.InteractableType, byte> dictionary2 = dictionary;
+                                        Scp079Interactable.InteractableType type = scp079Interactable3.type;
+                                        byte b = dictionary2[type];
+                                        dictionary2[type] = (byte)(b + 1);
+                                    }
+                                    else
+                                    {
+                                        dictionary[scp079Interactable3.type] = 1;
+                                    }
+                                    if (scp079Interactable3.type == Scp079Interactable.InteractableType.ElevatorTeleport)
+                                    {
+                                        scp079Interactable2 = scp079Interactable3;
+                                    }
+                                }
+                                string text2;
+                                if (scp079Interactable2 == null)
+                                {
+                                    text2 = "None of the " + __instance.nearbyInteractables.Count + " were an ElevatorTeleport, found: ";
+                                    using (Dictionary<Scp079Interactable.InteractableType, byte>.Enumerator enumerator2 = dictionary.GetEnumerator())
+                                    {
+                                        while (enumerator2.MoveNext())
+                                        {
+                                            KeyValuePair<Scp079Interactable.InteractableType, byte> keyValuePair = enumerator2.Current;
+                                            text2 = string.Concat(new object[]
+                                            {
+                                        text2,
+                                        keyValuePair.Value,
+                                        "x",
+                                        keyValuePair.Key.ToString().Substring(keyValuePair.Key.ToString().Length - 4),
+                                        " "
+                                            });
+                                        }
+                                        goto IL_755;
+                                    }
+                                }
+                                if (scp079Interactable2.optionalObject == null)
+                                {
+                                    text2 = "Optional object is missing.";
+                                }
+                                else if (scp079Interactable2.optionalObject.GetComponent<Camera079>() == null)
+                                {
+                                    string str = "";
+                                    Transform transform = scp079Interactable2.optionalObject.transform;
+                                    for (int i = 0; i < 5; i++)
+                                    {
+                                        str = transform.name + str;
+                                        if (!(transform.parent != null))
+                                        {
+                                            break;
+                                        }
+                                        transform = transform.parent;
+                                    }
+                                    text2 = "Camera is missing at " + str;
+                                }
+                                else
+                                {
+                                    text2 = "Unknown error";
+                                }
+                            IL_755:
+                                GameCore.Console.AddDebugLog("SCP079", "Could not find the second elevator: " + text2, MessageImportance.LeastImportant, false);
+                                return false;
+                            }
+                            break;
+                        }
+                    case "ELEVATORUSE":
+                        {
+                            float manaFromLabel = __instance.GetManaFromLabel("Elevator Use", __instance.abilities);
+                            string elevatorName = string.Empty;
+                            if (array.Length > 1)
+                            {
+                                elevatorName = array[1];
+                            }
+                            Elevator synElevator = Map.Get.Elevators.Find(_ => _.Name == elevatorName);
+                            Scp079EventMisc.InteractionResult intendedResult;
+                            if (manaFromLabel <= __instance.curMana)
+                            {
+                                intendedResult = Scp079EventMisc.InteractionResult.NoEnergy;
+                            }
+                            else if (synElevator == null || (AlphaWarheadController.Host.timeToDetonation == 0f || !synElevator.Operative || synElevator.Locked))
+                            {
+                                intendedResult = Scp079EventMisc.InteractionResult.Disallow;
+                            }
+                            else
+                            {
+                                intendedResult = Scp079EventMisc.InteractionResult.Allow;
+                            }
+
+                            intendedResult = manaFromLabel <= __instance.curMana ? Scp079EventMisc.InteractionResult.Allow : Scp079EventMisc.InteractionResult.NoEnergy;
+
+                            SynapseController.Server.Events.Scp.Scp079.Invoke079ElevatorUse(
+                                __instance.gameObject.GetPlayer(),
+                                manaFromLabel,
+                                synElevator,
+                                intendedResult,
+                                out var actualResult
+                                );
+
+                            switch (actualResult)
+                            {
+                                case Scp079EventMisc.InteractionResult.Allow:
+                                    {
+                                        if (synElevator.Lift.UseLift())
+                                        {
+                                            __instance.Mana -= manaFromLabel;
+                                            bool flag3 = false;
+                                            foreach (Lift.Elevator elevator in synElevator.Lift.elevators)
+                                            {
+                                                __instance.AddInteractionToHistory(elevator.door.GetComponentInParent<Scp079Interactable>().gameObject, array[0], !flag3);
+                                                flag3 = true;
+                                            }
+                                        }
+                                        return false;
+                                    }
+                                case Scp079EventMisc.InteractionResult.Disallow:
+                                    {
+                                        return false;
+                                    }
+                                case Scp079EventMisc.InteractionResult.NoEnergy:
+                                    {
+                                        __instance.RpcNotEnoughMana(manaFromLabel, __instance.curMana);
+                                        return false;
+                                    }
+                            }
+
+                            break;
+                        }
+                    case "DOORLOCK":
+                        {
+                            if (AlphaWarheadController.Host.inProgress)
+                            {
+                                return false;
+                            }
+                            if (target == null)
+                            {
+                                GameCore.Console.AddDebugLog("SCP079", "The door lock command requires a target.", MessageImportance.LessImportant, false);
+                                return false;
+                            }
+                            if (doorVariant == null)
+                            {
+                                return false;
+                            }
+                            if (doorVariant.TryGetComponent(out DoorNametagExtension doorNametagExtension))
+                            {
+                                if (list != null && list.Count > 0 && list.Contains(doorNametagExtension.GetName))
+                                {
+                                    GameCore.Console.AddDebugLog("SCP079", "Door access denied by the server.", MessageImportance.LeastImportant, false);
+                                    return false;
+                                }
+                            }
+
+                            float manaFromLabel = __instance.GetManaFromLabel("Door Lock Minimum", __instance.abilities);
+
+                            var action = ((DoorLockReason)doorVariant.ActiveLocks).HasFlag(DoorLockReason.Regular079) ? Scp079EventMisc.DoorAction.Unlocking : Scp079EventMisc.DoorAction.Locking;
+
+                            Scp079EventMisc.InteractionResult intendedResult;
+                            if (action == Scp079EventMisc.DoorAction.Unlocking)
+                            {
+                                intendedResult = __instance.lockedDoors.Contains(doorVariant.netId) ? Scp079EventMisc.InteractionResult.Allow : Scp079EventMisc.InteractionResult.Disallow;
+                            }
+                            else
+                            {
+                                intendedResult = manaFromLabel <= __instance.curMana ? Scp079EventMisc.InteractionResult.Allow : Scp079EventMisc.InteractionResult.NoEnergy;
+                            }
+
+                            SynapseController.Server.Events.Scp.Scp079.Invoke079DoorInteract(
+                                __instance.gameObject.GetPlayer(),
+                                action,
+                                intendedResult,
+                                manaFromLabel,
+                                doorVariant.GetDoor(),
+                                out var actualResult
+                                );
+
+                            switch (actualResult)
+                            {
+                                case Scp079EventMisc.InteractionResult.Allow when action == Scp079EventMisc.DoorAction.Unlocking:
+                                    {
+                                        __instance.lockedDoors.Remove(doorVariant.netId);
+                                        doorVariant.ServerChangeLock(DoorLockReason.Regular079, false);
+                                        return false;
+                                    }
+                                case Scp079EventMisc.InteractionResult.Allow when action == Scp079EventMisc.DoorAction.Locking:
+                                    {
+                                        if (!__instance.lockedDoors.Contains(doorVariant.netId))
+                                        {
+                                            __instance.lockedDoors.Add(doorVariant.netId);
+                                        }
+                                        doorVariant.ServerChangeLock(DoorLockReason.Regular079, true);
+                                        __instance.AddInteractionToHistory(doorVariant.gameObject, array[0], true);
+                                        __instance.Mana -= __instance.GetManaFromLabel("Door Lock Start", __instance.abilities);
+                                        return false;
+                                    }
+                                case Scp079EventMisc.InteractionResult.Disallow when action == Scp079EventMisc.DoorAction.Unlocking:
+                                    {
+                                        return false;
+                                    }
+                                case Scp079EventMisc.InteractionResult.Disallow when action == Scp079EventMisc.DoorAction.Locking:
+                                    {
+                                        return false;
+                                    }
+                                case Scp079EventMisc.InteractionResult.NoEnergy when action == Scp079EventMisc.DoorAction.Unlocking:
+                                    {
+                                        return false;
+                                    }
+                                case Scp079EventMisc.InteractionResult.NoEnergy when action == Scp079EventMisc.DoorAction.Locking:
+                                    {
+                                        __instance.RpcNotEnoughMana(manaFromLabel, __instance.curMana);
+                                        return false;
+                                    }
+                            }
+                            break;
+                        }
+                    case "SPEAKER":
+                        {
+                            string text3 = __instance.currentZone + "/" + __instance.currentRoom + "/Scp079Speaker";
+                            GameObject gameObject = GameObject.Find(text3);
+                            float manaFromLabel = __instance.GetManaFromLabel("Speaker Start", __instance.abilities) * 1.5f;
+
+                            Scp079EventMisc.InteractionResult intendedResult;
+                            if (gameObject == null)
+                            {
+                                intendedResult = Scp079EventMisc.InteractionResult.Disallow;
+                            }
+                            else if (manaFromLabel <= __instance.curMana)
+                            {
+                                intendedResult = Scp079EventMisc.InteractionResult.Allow;
+                            }
+                            else
+                            {
+                                intendedResult = Scp079EventMisc.InteractionResult.NoEnergy;
+                            }
+
+                            SynapseController.Server.Events.Scp.Scp079.Invoke079SpeakerInteract(
+                                __instance.gameObject.GetPlayer(),
+                                manaFromLabel,
+                                intendedResult,
+                                out var actualResult
+                                );
+
+                            switch (actualResult)
+                            {
+                                case Scp079EventMisc.InteractionResult.Allow:
+                                    {
+                                        __instance.Mana -= manaFromLabel;
+                                        __instance.Speaker = text3;
+                                        __instance.AddInteractionToHistory(gameObject, array[0], true);
+                                        return false;
+                                    }
+                                case Scp079EventMisc.InteractionResult.NoEnergy:
+                                    {
+                                        __instance.RpcNotEnoughMana(manaFromLabel, __instance.curMana);
+                                        return false;
+                                    }
+                            }
+                            break;
+                        }
+                    case "STOPSPEAKER":
+                        {
+                            __instance.Speaker = string.Empty;
+                            break;
+                        }
+                    case "DOOR":
+                        {
+                            if (AlphaWarheadController.Host.inProgress)
+                            {
+                                return false;
+                            }
+                            if (target == null)
+                            {
+                                GameCore.Console.AddDebugLog("SCP079", "The door command requires a target.", MessageImportance.LessImportant, false);
+                                return false;
+                            }
+                            if (!flag)
+                            {
+                                return false;
+                            }
+                            if (doorVariant.TryGetComponent(out DoorNametagExtension doorNametagExtension2))
+                            {
+                                if (list != null && list.Count > 0 && list.Contains(doorNametagExtension2.GetName))
+                                {
+                                    GameCore.Console.AddDebugLog("SCP079", "Door access denied by the server.", MessageImportance.LeastImportant, false);
+                                    return false;
+                                }
+                            }
+                            string text4 = doorVariant.RequiredPermissions.RequiredPermissions.ToString();
+                            float manaFromLabel = __instance.GetManaFromLabel("Door Interaction " + (text4.Contains(",") ? text4.Split(',')[0] : text4), __instance.abilities);
+
+                            var action = doorVariant.TargetState ? Scp079EventMisc.DoorAction.Closing : Scp079EventMisc.DoorAction.Opening;
+                            var intendedResult = manaFromLabel <= __instance.curMana ? Scp079EventMisc.InteractionResult.Allow : Scp079EventMisc.InteractionResult.NoEnergy;
+                            SynapseController.Server.Events.Scp.Scp079.Invoke079DoorInteract(
+                                __instance.gameObject.GetPlayer(),
+                                action,
+                                intendedResult,
+                                manaFromLabel,
+                                doorVariant.GetDoor(),
+                                out var actualResult
+                                );
+
+                            switch (actualResult)
+                            {
+                                case Scp079EventMisc.InteractionResult.Allow:
+                                    {
+                                        bool targetState = doorVariant.TargetState;
+                                        doorVariant.ServerInteract(ReferenceHub.GetHub(__instance.gameObject), 0);
+                                        if (targetState != doorVariant.TargetState)
+                                        {
+                                            __instance.Mana -= manaFromLabel;
+                                            __instance.AddInteractionToHistory(target, array[0], true);
+                                            GameCore.Console.AddDebugLog("SCP079", "Door state changed.", MessageImportance.LeastImportant, false);
+                                            return false;
+                                        }
+                                        GameCore.Console.AddDebugLog("SCP079", "Door state failed to change.", MessageImportance.LeastImportant, false);
+                                        return false;
+                                    }
+                                case Scp079EventMisc.InteractionResult.Disallow:
+                                    {
+                                        GameCore.Console.AddDebugLog("SCP079", "Door access denied by the server.", MessageImportance.LeastImportant, false);
+                                        return false;
+                                    }
+                                case Scp079EventMisc.InteractionResult.NoEnergy:
+                                    {
+                                        GameCore.Console.AddDebugLog("SCP079", "Not enough mana.", MessageImportance.LeastImportant, false);
+                                        __instance.RpcNotEnoughMana(manaFromLabel, __instance.curMana);
+                                        return false;
+                                    }
+                            }
+                            break;
+                        }
+                }
+
+            }
+            catch (System.Exception e)
+            {
+                Synapse.Api.Logger.Get.Warn($"{e}");
+            }
+
+            return false;
+        }
+    }
+}

--- a/Synapse/Patches/EventsPatches/ScpPatches/Scp079/Scp079BulkPatch.cs
+++ b/Synapse/Patches/EventsPatches/ScpPatches/Scp079/Scp079BulkPatch.cs
@@ -40,7 +40,7 @@ namespace Synapse.Patches.EventsPatches.ScpPatches.Scp079
                     return false;
                 }
                 DoorVariant doorVariant = null;
-                bool flag = target != null && target.TryGetComponent<DoorVariant>(out doorVariant);
+                bool flag = target != null && target.TryGetComponent(out doorVariant);
                 List<string> list = GameCore.ConfigFile.ServerConfig.GetStringList("scp079_door_blacklist") ?? new List<string>();
                 string text = array[0];
 
@@ -65,7 +65,7 @@ namespace Synapse.Patches.EventsPatches.ScpPatches.Scp079
                             SynapseController.Server.Events.Scp.Scp079.Invoke079TeslaInteract(
                                 __instance.gameObject.GetPlayer(),
                                 manaFromLabel,
-                                tesla.Room,
+                                tesla?.Room,
                                 tesla,
                                 intendedResult,
                                 out var actualResult
@@ -579,6 +579,7 @@ namespace Synapse.Patches.EventsPatches.ScpPatches.Scp079
 
                             var action = doorVariant.TargetState ? Scp079EventMisc.DoorAction.Closing : Scp079EventMisc.DoorAction.Opening;
                             var intendedResult = manaFromLabel <= __instance.curMana ? Scp079EventMisc.InteractionResult.Allow : Scp079EventMisc.InteractionResult.NoEnergy;
+                            
                             SynapseController.Server.Events.Scp.Scp079.Invoke079DoorInteract(
                                 __instance.gameObject.GetPlayer(),
                                 action,

--- a/Synapse/Patches/EventsPatches/ScpPatches/Scp079/Scp079CameraSwitchPatch.cs
+++ b/Synapse/Patches/EventsPatches/ScpPatches/Scp079/Scp079CameraSwitchPatch.cs
@@ -1,0 +1,31 @@
+﻿using HarmonyLib;
+using Synapse.Api;
+
+namespace Synapse.Patches.EventsPatches.ScpPatches.Scp079
+{
+    [HarmonyPatch(typeof(Scp079PlayerScript), nameof(Scp079PlayerScript.RpcSwitchCamera))]
+    internal static class Scp079CameraSwitchPatch
+    {
+        private static bool Prefix(Scp079PlayerScript __instance, ushort camId, bool lookatRotation)
+        {
+            Camera079 camera = Server.Get.Map.Cameras.Find(cam => cam.cameraId == camId);
+            Player player = __instance.GetPlayer();
+            bool spawning = false;
+            if (!player.Scp079Controller.Spawned)
+            {
+                spawning = true;
+                player.Scp079Controller.Spawned = true;
+            }
+
+            SynapseController.Server.Events.Scp.Scp079.Invoke079CameraSwitch(
+                __instance.gameObject.GetPlayer(),
+                camera,
+                lookatRotation,
+                spawning,
+                out var allowed
+                );
+
+            return allowed;
+        }
+    }
+}

--- a/Synapse/Synapse.csproj
+++ b/Synapse/Synapse.csproj
@@ -219,6 +219,7 @@
     <Compile Include="Patches\EventsPatches\RoundPatches\WaitingandEndPatch.cs" />
     <Compile Include="Patches\EventsPatches\ScpPatches\Scp049\Scp049AttackPatch.cs" />
     <Compile Include="Patches\EventsPatches\ScpPatches\Scp049\Scp0492AttackPatch.cs" />
+    <Compile Include="Patches\EventsPatches\ScpPatches\Scp079\Scp079BulkPatch.cs" />
     <Compile Include="Patches\EventsPatches\ScpPatches\Scp079\Scp079RecontainPatch.cs" />
     <Compile Include="Patches\EventsPatches\ScpPatches\Scp096\Scp096AttackPatch.cs" />
     <Compile Include="Patches\EventsPatches\ScpPatches\Scp096\Scp096TargetPatches.cs" />
@@ -282,9 +283,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Refs\Assembly-CSharp-Publicized.dll</HintPath>
     </Reference>
-    <Reference Include="EmbedIO, Version=3.4.3.0, Culture=neutral, PublicKeyToken=5e5f048b6e04267e">
+    <Reference Include="EmbedIO, Version=3.4.3.0, Culture=neutral, PublicKeyToken=5e5f048b6e04267e, processorArchitecture=MSIL">
       <HintPath>..\packages\EmbedIO.3.4.3\lib\netstandard2.0\EmbedIO.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="LiteDB, Version=5.0.9.0, Culture=neutral, PublicKeyToken=4ee40123013c9f27, processorArchitecture=MSIL">
       <HintPath>..\packages\LiteDB.5.0.9\lib\net45\LiteDB.dll</HintPath>

--- a/Synapse/Synapse.csproj
+++ b/Synapse/Synapse.csproj
@@ -220,6 +220,7 @@
     <Compile Include="Patches\EventsPatches\ScpPatches\Scp049\Scp049AttackPatch.cs" />
     <Compile Include="Patches\EventsPatches\ScpPatches\Scp049\Scp0492AttackPatch.cs" />
     <Compile Include="Patches\EventsPatches\ScpPatches\Scp079\Scp079BulkPatch.cs" />
+    <Compile Include="Patches\EventsPatches\ScpPatches\Scp079\Scp079CameraSwitchPatch.cs" />
     <Compile Include="Patches\EventsPatches\ScpPatches\Scp079\Scp079RecontainPatch.cs" />
     <Compile Include="Patches\EventsPatches\ScpPatches\Scp096\Scp096AttackPatch.cs" />
     <Compile Include="Patches\EventsPatches\ScpPatches\Scp096\Scp096TargetPatches.cs" />

--- a/Synapse/SynapseController.cs
+++ b/Synapse/SynapseController.cs
@@ -26,7 +26,7 @@ public class SynapseController
     {
         CustomNetworkManager.Modded = true;
         BuildInfoCommand.ModDescription = $"Plugin Framework: Synapse\nSynapse Version: {SynapseVersion}\nDescription: Synapse is a heavily modded server software using extensive runtime patching to make development faster and the usage more accessible to end-users";
-        
+
         PatchMethods();
         try
         {
@@ -38,15 +38,15 @@ public class SynapseController
 
             PluginLoader.ActivatePlugins();
         }
-        catch(Exception e)
+        catch (Exception e)
         {
             Server.Logger.Error($"Error while Initialising Synapse! Please fix the Issue and restart your Server:\n{e}");
             return;
         }
 
         Server.Logger.Info("Synapse is now ready!");
-    } 
-    
+    }
+
     private void PatchMethods()
     {
         try
@@ -55,7 +55,7 @@ public class SynapseController
             instance.PatchAll();
             Server.Logger.Info("Harmony Patching was sucessfully!");
         }
-        catch(Exception e)
+        catch (Exception e)
         {
             Server.Logger.Error($"Harmony Patching threw an error:\n\n {e}");
         }

--- a/Synapse/packages.config
+++ b/Synapse/packages.config
@@ -5,14 +5,14 @@
   <package id="LiteDB" version="5.0.9" targetFramework="net472" />
   <package id="Microsoft.Extensions.Caching.Abstractions" version="6.0.0-preview.1.21102.12" targetFramework="net472" />
   <package id="Microsoft.Extensions.Caching.Memory" version="6.0.0-preview.1.21102.12" targetFramework="net472" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0-preview.1.21102.12" targetFramework="net472" />
   <package id="Microsoft.Extensions.Logging.Abstractions" version="6.0.0-preview.1.21102.12" targetFramework="net472" />
   <package id="Microsoft.Extensions.Options" version="6.0.0-preview.1.21102.12" targetFramework="net472" />
   <package id="Microsoft.Extensions.Primitives" version="6.0.0-preview.1.21102.12" targetFramework="net472" />
-  <package id="System.Memory" version="4.5.4" targetFramework="net472" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0-preview.1.21102.12" targetFramework="net472" />
-  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0-preview.1.21102.12" targetFramework="net472" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
+  <package id="System.Memory" version="4.5.4" targetFramework="net472" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0-preview.1.21102.12" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
   <package id="Unosquare.Swan.Lite" version="3.0.0" targetFramework="net472" />
   <package id="YamlDotNet" version="8.1.2" targetFramework="net472" />


### PR DESCRIPTION
## Added various 079 events

Added necessary types:

### Scp079EventMisc
- enum InteractionResult
  - Allow
  - Disallow
  - NoEnergy
- enum DoorAction
  - Opening
  - Closing
  - Locking
  - Unlocking

---

## Events:
| Event Name | Description |  EventArgs |
| ------------- | ------------- | ------------- |
| DoorInteract | Invoked when 079 tries to: open, close, lock or unlock a door | Scp079DoorInteract |
| SpeakerInteract | Invoked when 079 tries to use a speaker | Scp079SpeakerInteract |
| ElevatorInteract | Invoked when 079 tries to interact with an elevator | Scp079ElevatorInteract |
| RoomLockdown| Invoked when 079 tries to lockdown a room (close doors, turn off lights) | Scp079RoomLockdown |
| TeslaInteract| Invoked when 079 tries to use a tesla | Scp079TeslaInteract |
| CameraSwitch| Invoked when 079 tries to switch a camera | Scp079CameraSwitch |

---

## EventArgs
| EventArgs Name | Content |
| ------------- | ------------- |
| Scp079DoorInteractEventArgs | 079 Player, DoorAction, EnergyNeeded, Door, Result | 
| Scp079SpeakerInteractEventArgs | 079 Player, EnergyNeeded, Result | 
| Scp079ElevatorInteractEventArgs | 079 Player, EnergyNeeded, Elevator, Result | 
| Scp079RoomLockdownEventArgs | 079 Player, EnergyNeeded, Room, LightsOut Result | 
| Scp079TeslaInteractEventArgs | 079 Player, EnergyNeeded, Room, Tesla, Result | 
| Scp079CameraSwitchEventArgs | 079 Player, Camera079, Spawning, MapSwitch, Allow | 

---

### Map.Cameras
A list of all `Camera079` cameras on from all rooms

### Room.Cameras
A list of all `Camera079` cameras in that room
