### PR TITLE
improve Ragdoll & None Role

### DIFF
--- a/Synapse3.SynapseModule/Events/PlayerEvents.cs
+++ b/Synapse3.SynapseModule/Events/PlayerEvents.cs
@@ -335,11 +335,12 @@ public class DamageEvent : PlayerInteractEvent
 
 public class DeathEvent : PlayerInteractEvent
 {
-    public DeathEvent(SynapsePlayer player, bool allow, SynapsePlayer attacker, DamageType damageType, float lastTakenDamage) : base(player, allow)
+    public DeathEvent(SynapsePlayer player, bool allow, SynapsePlayer attacker, DamageType damageType, float lastTakenDamage, string message) : base(player, allow)
     {
         Attacker = attacker;
         DamageType = damageType;
         LastTakenDamage = lastTakenDamage;
+        DeathMesasge = message;
     }
 
     public SynapsePlayer Attacker { get; }
@@ -347,6 +348,8 @@ public class DeathEvent : PlayerInteractEvent
     public DamageType DamageType { get; }
     
     public float LastTakenDamage { get; }
+
+    public string DeathMesasge { get; set; }
 }
 
 public class FreePlayerEvent : PlayerInteractEvent

--- a/Synapse3.SynapseModule/Events/PlayerEvents.cs
+++ b/Synapse3.SynapseModule/Events/PlayerEvents.cs
@@ -340,7 +340,7 @@ public class DeathEvent : PlayerInteractEvent
         Attacker = attacker;
         DamageType = damageType;
         LastTakenDamage = lastTakenDamage;
-        DeathMesasge = message;
+        DeathMessage = message;
     }
 
     public SynapsePlayer Attacker { get; }
@@ -349,7 +349,7 @@ public class DeathEvent : PlayerInteractEvent
     
     public float LastTakenDamage { get; }
 
-    public string DeathMesasge { get; set; }
+    public string DeathMessage { get; set; }
 }
 
 public class FreePlayerEvent : PlayerInteractEvent

--- a/Synapse3.SynapseModule/Map/Objects/FakeInfoManger.cs
+++ b/Synapse3.SynapseModule/Map/Objects/FakeInfoManger.cs
@@ -1,0 +1,66 @@
+﻿using Synapse3.SynapseModule.Player;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Synapse3.SynapseModule.Map.Objects;
+
+public class FakeInfoManger<TInfo> : IJoinUpdate
+{
+    private readonly IFakableObjectInfo<TInfo> _fakableObject;
+    private readonly MirrorService _mirror;
+    private readonly PlayerService _playerService;
+    private readonly TInfo _defaultInfo;
+    private readonly Dictionary<SynapsePlayer, TInfo> _sendInfo = new();
+
+    public FakeInfoManger(IFakableObjectInfo<TInfo> fakableObject, MirrorService mirror, PlayerService playerService, TInfo defaultInfo)
+    {
+        _fakableObject = fakableObject;
+        _mirror = mirror;
+        _playerService = playerService;
+        _defaultInfo = defaultInfo;
+        _playerService.JoinUpdates.Add(this);
+    }
+
+    public void UpdateAll()
+    {
+        foreach (var player in _playerService.Players)
+        {
+            UpdatePlayer(player);
+        }
+    }
+
+    public bool NeedsJoinUpdate => true;
+    public void UpdatePlayer(SynapsePlayer player)
+    {
+        var info = _defaultInfo;
+        if (ToPlayerVisibleInfo.ContainsKey(player))
+        {
+            info = ToPlayerVisibleInfo[player];
+        }
+        else
+        {
+            foreach (var condition in VisibleInfoCondition)
+            {
+                if (condition.Key.Invoke(player))
+                {
+                    info = condition.Value;
+                    break;
+                }
+            }
+        }
+
+        //This will prevent to send unnecessary packages from being send
+        if (_sendInfo.ContainsKey(player) && _sendInfo[player].Equals(info))
+            return;
+        _sendInfo[player] = info;
+
+        _fakableObject.SendInfo(player, info);
+    }
+
+    public Dictionary<Func<SynapsePlayer, bool>, TInfo> VisibleInfoCondition { get; set; } = new();
+    public Dictionary<SynapsePlayer, TInfo> ToPlayerVisibleInfo { get; set; } = new();
+}
+

--- a/Synapse3.SynapseModule/Map/Objects/FakeInfoManger.cs
+++ b/Synapse3.SynapseModule/Map/Objects/FakeInfoManger.cs
@@ -9,16 +9,14 @@ namespace Synapse3.SynapseModule.Map.Objects;
 
 public class FakeInfoManger<TInfo> : IJoinUpdate
 {
-    private readonly IFakableObjectInfo<TInfo> _fakableObject;
-    private readonly MirrorService _mirror;
+    private readonly IFakeAbleObjectInfo<TInfo> _fakeAbleObject;
     private readonly PlayerService _playerService;
     private readonly TInfo _defaultInfo;
     private readonly Dictionary<SynapsePlayer, TInfo> _sendInfo = new();
 
-    public FakeInfoManger(IFakableObjectInfo<TInfo> fakableObject, MirrorService mirror, PlayerService playerService, TInfo defaultInfo)
+    public FakeInfoManger(IFakeAbleObjectInfo<TInfo> fakeAbleObject, PlayerService playerService, TInfo defaultInfo)
     {
-        _fakableObject = fakableObject;
-        _mirror = mirror;
+        _fakeAbleObject = fakeAbleObject;
         _playerService = playerService;
         _defaultInfo = defaultInfo;
         _playerService.JoinUpdates.Add(this);
@@ -57,7 +55,7 @@ public class FakeInfoManger<TInfo> : IJoinUpdate
             return;
         _sendInfo[player] = info;
 
-        _fakableObject.SendInfo(player, info);
+        _fakeAbleObject.SendInfo(player, info);
     }
 
     public Dictionary<Func<SynapsePlayer, bool>, TInfo> VisibleInfoCondition { get; set; } = new();

--- a/Synapse3.SynapseModule/Map/Objects/IFakableObjectInfo.cs
+++ b/Synapse3.SynapseModule/Map/Objects/IFakableObjectInfo.cs
@@ -1,0 +1,11 @@
+﻿using Synapse3.SynapseModule.Player;
+
+namespace Synapse3.SynapseModule.Map.Objects;
+
+public interface IFakableObjectInfo<TInfo>
+{
+    void SendInfo(SynapsePlayer player, TInfo info);
+
+    FakeInfoManger<TInfo> FakeInfoManger { get; }
+
+}

--- a/Synapse3.SynapseModule/Map/Objects/IFakeAbleObjectInfo.cs
+++ b/Synapse3.SynapseModule/Map/Objects/IFakeAbleObjectInfo.cs
@@ -2,10 +2,9 @@
 
 namespace Synapse3.SynapseModule.Map.Objects;
 
-public interface IFakableObjectInfo<TInfo>
+public interface IFakeAbleObjectInfo<TInfo>
 {
     void SendInfo(SynapsePlayer player, TInfo info);
 
     FakeInfoManger<TInfo> FakeInfoManger { get; }
-
 }

--- a/Synapse3.SynapseModule/Map/Objects/SynapseRagdoll.cs
+++ b/Synapse3.SynapseModule/Map/Objects/SynapseRagdoll.cs
@@ -1,17 +1,23 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Mirror;
+using Neuron.Core.Logging;
+using PlayableScps;
+using PlayerStatsSystem;
 using Synapse3.SynapseModule.Enums;
 using Synapse3.SynapseModule.Map.Schematic;
 using Synapse3.SynapseModule.Player;
+using Synapse3.SynapseModule.Role;
 using UnityEngine;
 
 namespace Synapse3.SynapseModule.Map.Objects;
 
-public class SynapseRagdoll : NetworkSynapseObject
+public class SynapseRagdoll : NetworkSynapseObject, IFakableObjectInfo<SynapseRagdoll.Info>
 {
     public static Dictionary<RoleType, Ragdoll> Prefabs = new ();
 
     private readonly PlayerService _player;
+    private readonly MirrorService _mirror;
 
     public Vector3 OriginalRagdollScale { get; private set; }
     public Ragdoll Ragdoll { get; }
@@ -20,7 +26,7 @@ public class SynapseRagdoll : NetworkSynapseObject
     public override NetworkIdentity NetworkIdentity => Ragdoll.netIdentity;
     public override void Refresh()
     {
-        Ragdoll.NetworkInfo = new RagdollInfo(_player.Host, DamageType.GetUniversalDamageHandler(), RoleType, Position, Rotation, Nick, Ragdoll.NetworkInfo.CreationTime);
+        FakeInfoManger.UpdateAll();
         base.Refresh();
     }
     public override void OnDestroy()
@@ -30,35 +36,70 @@ public class SynapseRagdoll : NetworkSynapseObject
         
         if (Parent is SynapseSchematic schematic) schematic._ragdolls.Remove(this);
     }
-
     public override Vector3 Scale
     {
         get => RevertScale(base.Scale);
         set => base.Scale = CreateScale(value);
     }
-
+    
     public DamageType DamageType { get; private set; }
     public RoleType RoleType { get; private set; }
-
     public string Nick { get; private set; }
-
+    public string CustomReason { get; private set; }
+    public bool CanBeRevive { get; set; }
+    public bool CanBeReviveInTime => Ragdoll.Info.ExistenceTime <= Scp049.ReviveEligibilityDuration;
+    public uint RoleID { get; private set; }
+    public FakeInfoManger<Info> FakeInfoManger { get; private set; }
     public SynapsePlayer Owner => _player.GetPlayer(Ragdoll.Info.OwnerHub.playerId);
 
-    public SynapseRagdoll(RoleType role, DamageType damage, Vector3 pos, Quaternion rot, Vector3 scale, string nick) : this()
+    public SynapseRagdoll(RoleType role, string reason, Vector3 pos, Quaternion rot, Vector3 scale,
+        string nick, SynapsePlayer player = null, bool canBeRevive = false, uint roleID = RoleService.NoneRole) : this()
     {
-        Ragdoll = CreateRagdoll(role, damage, pos, rot, scale, nick);
+        CanBeRevive = canBeRevive;
+        RoleID = roleID;
+        Ragdoll = CreateRagdoll(role, reason, pos, rot, scale, nick, player);
+        SetUp(role, DamageType.CustomReason, nick);
+    }
+
+    public SynapseRagdoll(RoleType role, DamageType damage, Vector3 pos, Quaternion rot, Vector3 scale, 
+        string nick, SynapsePlayer player = null, bool canBeRevive = false, uint roleID = RoleService.NoneRole) : this()
+    {
+        CanBeRevive = canBeRevive;
+        RoleID = roleID;
+        Ragdoll = CreateRagdoll(role, damage, pos, rot, scale, nick, player);
         SetUp(role, damage, nick);
     }
 
-    internal SynapseRagdoll(Ragdoll ragdoll) : this()
+    internal SynapseRagdoll(Ragdoll ragdoll, uint roleID, bool canBeRive) : this()
+    {
+        RoleID = roleID;
+        CanBeRevive = canBeRive;
+        Ragdoll = ragdoll;
+        SetUp(ragdoll.Info.RoleType, ragdoll.Info.Handler.GetDamageType(), ragdoll.Info.Nickname);
+    }
+
+    internal SynapseRagdoll(Ragdoll ragdoll, bool isAfterDeath = false) : this()
     {
         Ragdoll = ragdoll;
-        SetUp(ragdoll.NetworkInfo.RoleType, ragdoll.NetworkInfo.Handler.GetDamageType(), ragdoll.NetworkInfo.Nickname);
+        if (isAfterDeath && Owner != null)
+        {
+            CanBeRevive = Owner.TeamID != (int)Team.SCP;
+            RoleID = Owner.RoleID;
+        }
+        else
+        {
+            CanBeRevive = false;
+            RoleID = RoleService.NoneRole;
+        }
+
+        SetUp(ragdoll.Info.RoleType, ragdoll.Info.Handler.GetDamageType(), ragdoll.Info.Nickname);
     }
+
 
     private SynapseRagdoll()
     {
         _player = Synapse.Get<PlayerService>();
+        _mirror = Synapse.Get<MirrorService>();
     }
 
     internal SynapseRagdoll(SchematicConfiguration.RagdollConfiguration configuration,
@@ -72,6 +113,7 @@ public class SynapseRagdoll : NetworkSynapseObject
         OriginalScale = configuration.Scale;
         CustomAttributes = configuration.CustomAttributes;
     }
+
     private void SetUp(RoleType role, DamageType damage, string nick)
     {
         Map._synapseRagdolls.Add(this);
@@ -82,14 +124,39 @@ public class SynapseRagdoll : NetworkSynapseObject
         RoleType = role;
         Nick = nick;
         MoveInElevator = true;
+        CanBeRevive = true;
+        //Position = Ragdoll.Info.StartPosition;
+
+        Info defaultInfo;
+        if (damage == DamageType.CustomReason && Ragdoll.Info.Handler is CustomReasonDamageHandler custom)
+        {
+            CustomReason = custom._deathReason;
+            defaultInfo = new Info(Owner, nick, role, custom._deathReason);
+        }
+        else
+        {
+            CustomReason = string.Empty;
+            defaultInfo = new Info(Owner, nick, role, damage);
+        }
+        FakeInfoManger = new FakeInfoManger<Info>(this, _mirror, _player, defaultInfo);
+        FakeInfoManger.UpdateAll();
     }
 
     private Ragdoll CreateRagdoll(RoleType role, DamageType damage, Vector3 pos, Quaternion rot, Vector3 scale,
-        string nick)
+        string nick, SynapsePlayer player)
     {
         var rag = CreateNetworkObject(Prefabs[role], pos, rot, scale);
-        rag.NetworkInfo = new RagdollInfo(_player.Host, damage.GetUniversalDamageHandler(), role, pos, rot, nick,
+        rag.Info = new RagdollInfo(player ?? _player.Host, damage.GetUniversalDamageHandler(), role, pos, rot, nick,
             NetworkTime.time);
+        return rag;
+    }
+
+    private Ragdoll CreateRagdoll(RoleType role, string deathReason, Vector3 pos, Quaternion rot, Vector3 scale,
+        string nick, SynapsePlayer player)
+    {
+        var rag = CreateNetworkObject(Prefabs[role], pos, rot, scale);
+        rag.Info = new RagdollInfo(player ?? _player.Host, new PlayerStatsSystem.CustomReasonDamageHandler(deathReason), 
+            role, pos, rot, nick, NetworkTime.time);
         return rag;
     }
 
@@ -114,4 +181,77 @@ public class SynapseRagdoll : NetworkSynapseObject
         currentScale.z *= OriginalRagdollScale.z;
         return currentScale;
     }
+
+    public void SendInfo(SynapsePlayer player, Info info)
+    {
+        DamageHandlerBase damageHandler = info.IsCustomReason ? 
+            new CustomReasonDamageHandler(info.CustomDeathReason) :
+            info.DamageType.GetUniversalDamageHandler();
+
+        var ragdollInfo = new RagdollInfo(info.Owner, damageHandler, info.RoleType, 
+            Position, Rotation, info.Nick, Ragdoll.Info.CreationTime);
+
+        player.SendNetworkMessage(_mirror.GetCustomVarMessage(Ragdoll, writer =>
+        {
+            writer.WriteUInt64(1ul);
+            writer.WriteRagdollInfo(ragdollInfo);
+        }));
+    }
+
+    public struct Info
+    {
+        public RoleType RoleType { get; set; }
+        public SynapsePlayer Owner { get; set; }
+        public string Nick { get; set; }
+        public DamageType DamageType { get; set; }
+        public bool IsCustomReason => DamageType == DamageType.CustomReason;
+
+        private string _customDeathReason;
+        public string CustomDeathReason 
+        { 
+            get => IsCustomReason ? _customDeathReason : String.Empty;
+            set => _customDeathReason = value; 
+        }
+
+        public Info(SynapsePlayer owner, string nick, RoleType roleType, string deathReason)
+        {
+            RoleType = roleType;
+            Owner = owner;
+            Nick = nick;
+            DamageType = DamageType.CustomReason;
+            _customDeathReason = deathReason;
+        }
+
+        public Info(SynapsePlayer owner, string nick, RoleType roleType, DamageType deathReason)
+        {
+            RoleType = roleType;
+            Owner = owner;
+            Nick = nick;
+            DamageType = deathReason;
+            _customDeathReason = String.Empty;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (object.ReferenceEquals(this, obj)) return true;
+
+            if (obj is not Info info) return false;
+
+            return RoleType == info.RoleType && Owner == info.Owner && Nick == info.Nick &&
+                DamageType == info.DamageType && CustomDeathReason == info.CustomDeathReason;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = -990623893;
+            hashCode = hashCode * -1521134295 + RoleType.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<SynapsePlayer>.Default.GetHashCode(Owner);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Nick);
+            hashCode = hashCode * -1521134295 + DamageType.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(CustomDeathReason);
+            return hashCode;
+        }
+
+    }
+
 }

--- a/Synapse3.SynapseModule/Map/Objects/SynapseRagdoll.cs
+++ b/Synapse3.SynapseModule/Map/Objects/SynapseRagdoll.cs
@@ -12,9 +12,9 @@ using UnityEngine;
 
 namespace Synapse3.SynapseModule.Map.Objects;
 
-public class SynapseRagdoll : NetworkSynapseObject, IFakableObjectInfo<SynapseRagdoll.Info>
+public class SynapseRagdoll : NetworkSynapseObject, IFakeAbleObjectInfo<SynapseRagdoll.Info>
 {
-    public static Dictionary<RoleType, Ragdoll> Prefabs = new ();
+    public static readonly Dictionary<RoleType, Ragdoll> Prefabs = new ();
 
     private readonly PlayerService _player;
     private readonly MirrorService _mirror;
@@ -48,7 +48,7 @@ public class SynapseRagdoll : NetworkSynapseObject, IFakableObjectInfo<SynapseRa
     public string CustomReason { get; private set; }
     public bool CanBeRevive { get; set; }
     public bool CanBeReviveInTime => Ragdoll.Info.ExistenceTime <= Scp049.ReviveEligibilityDuration;
-    public uint RoleID { get; private set; }
+    public uint RoleID { get; }
     public FakeInfoManger<Info> FakeInfoManger { get; private set; }
     public SynapsePlayer Owner => _player.GetPlayer(Ragdoll.Info.OwnerHub.playerId);
 
@@ -125,7 +125,6 @@ public class SynapseRagdoll : NetworkSynapseObject, IFakableObjectInfo<SynapseRa
         Nick = nick;
         MoveInElevator = true;
         CanBeRevive = true;
-        //Position = Ragdoll.Info.StartPosition;
 
         Info defaultInfo;
         if (damage == DamageType.CustomReason && Ragdoll.Info.Handler is CustomReasonDamageHandler custom)
@@ -138,7 +137,7 @@ public class SynapseRagdoll : NetworkSynapseObject, IFakableObjectInfo<SynapseRa
             CustomReason = string.Empty;
             defaultInfo = new Info(Owner, nick, role, damage);
         }
-        FakeInfoManger = new FakeInfoManger<Info>(this, _mirror, _player, defaultInfo);
+        FakeInfoManger = new FakeInfoManger<Info>(this, _player, defaultInfo);
         FakeInfoManger.UpdateAll();
     }
 

--- a/Synapse3.SynapseModule/Patches/PlayerPatches/DeathPatches.cs
+++ b/Synapse3.SynapseModule/Patches/PlayerPatches/DeathPatches.cs
@@ -41,8 +41,8 @@ internal static class DeathPatches
                 return false;
             }
             
-            if (ev.DeathMesasge != null)
-                handler = new CustomReasonDamageHandler(ev.DeathMesasge);
+            if (ev.DeathMessage != null)
+                handler = new CustomReasonDamageHandler(ev.DeathMessage);
 
             player.DeathPosition = player.Position;
             return true;

--- a/Synapse3.SynapseModule/Patches/PlayerPatches/DeathPatches.cs
+++ b/Synapse3.SynapseModule/Patches/PlayerPatches/DeathPatches.cs
@@ -35,6 +35,9 @@ internal static class DeathPatches
             var ev = new DeathEvent(player, true, attacker, damageType, damage, null);
             Synapse.Get<PlayerEvents>().Death.Raise(ev);
 
+            if (ev.DeathMesasge != null)
+                handler = new CustomReasonDamageHandler(ev.DeathMesasge);
+
             if (!ev.Allow)
             {
                 player.Health = 1;

--- a/Synapse3.SynapseModule/Patches/PlayerPatches/DeathPatches.cs
+++ b/Synapse3.SynapseModule/Patches/PlayerPatches/DeathPatches.cs
@@ -32,7 +32,7 @@ internal static class DeathPatches
                 attacker = Synapse.Get<PlayerService>().Players
                     .FirstOrDefault(x => x.ScpController.Scp106.PlayersInPocket.Contains(player));
 
-            var ev = new DeathEvent(player, true, attacker, damageType, damage);
+            var ev = new DeathEvent(player, true, attacker, damageType, damage, null);
             Synapse.Get<PlayerEvents>().Death.Raise(ev);
 
             if (!ev.Allow)
@@ -40,6 +40,9 @@ internal static class DeathPatches
                 player.Health = 1;
                 return false;
             }
+
+            if (ev.DeathMesasge != null)
+                handler = new CustomReasonDamageHandler(ev.DeathMesasge);
 
             player.DeathPosition = player.Position;
             return true;
@@ -54,7 +57,6 @@ internal static class DeathPatches
     [HarmonyPostfix]
     [HarmonyPatch(typeof(PlayerStats), nameof(PlayerStats.KillPlayer))]
     public static void PostDeath(PlayerStats __instance, bool __runOriginal)
-
     {
         try
         {

--- a/Synapse3.SynapseModule/Patches/PlayerPatches/DeathPatches.cs
+++ b/Synapse3.SynapseModule/Patches/PlayerPatches/DeathPatches.cs
@@ -35,15 +35,12 @@ internal static class DeathPatches
             var ev = new DeathEvent(player, true, attacker, damageType, damage, null);
             Synapse.Get<PlayerEvents>().Death.Raise(ev);
 
-            if (ev.DeathMesasge != null)
-                handler = new CustomReasonDamageHandler(ev.DeathMesasge);
-
             if (!ev.Allow)
             {
                 player.Health = 1;
                 return false;
             }
-
+            
             if (ev.DeathMesasge != null)
                 handler = new CustomReasonDamageHandler(ev.DeathMesasge);
 

--- a/Synapse3.SynapseModule/Patches/ScpPatches.cs
+++ b/Synapse3.SynapseModule/Patches/ScpPatches.cs
@@ -967,10 +967,10 @@ internal static class DecoratedScpPatches
 
             if (!ev2.FinishRevive)
             {
-                if (ragdoll.Ragdoll.Info.ExistenceTime > Scp049.ReviveEligibilityDuration)
+                if (!ragdoll.CanBeReviveInTime)
                     ev2.Allow = false;
                 
-                if (scp.ClassManager.Classes.SafeGet(ragdoll.RoleType).team == Team.SCP)
+                if (!ragdoll.CanBeRevive)
                     ev2.Allow = false;
 
                 var rigidbodies = ragdoll.Ragdoll.GetComponentsInChildren<Rigidbody>();

--- a/Synapse3.SynapseModule/Patches/WrapperPatches.cs
+++ b/Synapse3.SynapseModule/Patches/WrapperPatches.cs
@@ -62,8 +62,7 @@ internal static class WrapperPatches
     {
         try
         {
-            if (hub is null) return false;
-
+            if (hub == null) return false;
             var prefab = hub.characterClassManager.CurRole?.model_ragdoll;
 
             if (prefab == null || !Object.Instantiate(prefab).TryGetComponent<Ragdoll>(out var ragdoll))
@@ -71,7 +70,8 @@ internal static class WrapperPatches
 
             var info = new RagdollInfo(hub, handler, prefab.transform.localPosition,
                 prefab.transform.localRotation);
-
+            
+            ragdoll.Info = info;
             ragdoll.SetSyncVar(info, ref ragdoll.Info, 1uL); // I don't use NetworkInfo to not call the patch of the get
 
             NetworkServer.Spawn(ragdoll.gameObject);

--- a/Synapse3.SynapseModule/Player/FakeRoleManager.cs
+++ b/Synapse3.SynapseModule/Player/FakeRoleManager.cs
@@ -78,6 +78,7 @@ public class FakeRoleManager : IJoinUpdate
         get => _ownVisibleRole;
         set
         {
+            if (value == _ownVisibleRole) return;
             _ownVisibleRole = value;
             UpdatePlayer(_player);
         }
@@ -90,6 +91,7 @@ public class FakeRoleManager : IJoinUpdate
         get => _visibleRole;
         set
         {
+            if (value == _visibleRole) return;
             _visibleRole = value;
             foreach (var player in _playerService.Players)
             {

--- a/Synapse3.SynapseModule/Player/SynapsePlayerCommonMethods.cs
+++ b/Synapse3.SynapseModule/Player/SynapsePlayerCommonMethods.cs
@@ -132,7 +132,7 @@ public partial class SynapsePlayer
     /// <summary>
     /// Kills the Player
     /// </summary>
-    public void Kill() => Kill("Unknown Reason");
+    public bool Kill() => Kill("Unknown Reason");
 
     /// <summary>
     /// Kills the Player
@@ -242,7 +242,7 @@ public partial class SynapsePlayer
         }
 
         var allow = true;
-        var escapeRole = uint.MaxValue;
+        var escapeRole = RoleService.NoneRole;
         var changeTeam = false;
 
         foreach (var disarmedEntry in DisarmedPlayers.Entries)
@@ -285,7 +285,7 @@ public partial class SynapsePlayer
                 break;
         }
 
-        if (escapeRole == uint.MaxValue) allow = false;
+        if (escapeRole == RoleService.NoneRole) allow = false;
 
         var ev = new EscapeEvent(this, allow, escapeRole, RoleID == (int)RoleType.ClassD, changeTeam);
         _playerEvents.Escape.Raise(ev);

--- a/Synapse3.SynapseModule/Player/SynapsePlayerRole.cs
+++ b/Synapse3.SynapseModule/Player/SynapsePlayerRole.cs
@@ -70,7 +70,7 @@ public partial class SynapsePlayer
     {
         get
         {
-            if (CustomRole == null) return RoleType == RoleType.None ? uint.MaxValue : (uint)RoleType;
+            if (CustomRole == null) return RoleType == RoleType.None ? RoleService.NoneRole : (uint)RoleType;
             return CustomRole.Attribute.Id;
         }
         set

--- a/Synapse3.SynapseModule/Role/RoleService.cs
+++ b/Synapse3.SynapseModule/Role/RoleService.cs
@@ -20,6 +20,11 @@ public class RoleService : Service
     private readonly Synapse _synapseModule;
 
     /// <summary>
+    /// The value to use by synapse to designate <see cref="RoleType.None"/>
+    /// </summary>
+    public const uint NoneRole = uint.MaxValue;
+
+    /// <summary>
     /// The Hightest vanilla number for Roles
     /// </summary>
     public const uint HighestRole = (uint)RoleType.ChaosMarauder;


### PR DESCRIPTION
I add a générique [FakeInfoManger.cs](https://github.com/SynapseSL/Synapse/compare/synapse3...warquys:synapse3Dev?expand=1#diff-f3c247422e4d267e63ba59d9f6b0903a28665e5c23a80ba3c9850af107c3281b).
New proprets to the [SynapseRagdoll](https://github.com/SynapseSL/Synapse/compare/synapse3...warquys:synapse3Dev?expand=1#diff-5928ffb83a5afb2d5f15943e7b2368b41264d10018c6d0d86455813ae50a056a) and implement a FakeInfoManger to manage the info of the ragdoll.

It now possible to set custom info on ragdoll and set a custom death reason for the player and ragdoll in the DeathEvent.

Note : Change the info dont change the ragdoll prefab, only the info of the ragdoll. 
